### PR TITLE
Create `TaskComponent` and `TaskAttributeComponent`

### DIFF
--- a/app/components/controllers/task_attribute_component_controller.js
+++ b/app/components/controllers/task_attribute_component_controller.js
@@ -1,0 +1,53 @@
+import {Controller} from "@hotwired/stimulus";
+
+export default class extends Controller {
+  static targets = ["display", "edit"]
+
+  connect() {
+    this.selectOnFocus = this.selectOnFocus.bind(this)
+    this.autoResize = this.autoResize.bind(this)
+    this.edit = this.edit.bind(this)
+    this.display = this.display.bind(this)
+
+    this.editTarget.addEventListener("focusin", this.selectOnFocus)
+    document.addEventListener("input", this.autoResize);
+    document.addEventListener("task-component:edit", this.edit)
+    document.addEventListener("task-component:display", this.display)
+  }
+
+  disconnect() {
+    this.editTarget.removeEventListener("focusin", this.selectOnFocus)
+    document.removeEventListener("input", this.autoResize)
+    document.removeEventListener("task-component:edit", this.edit)
+    document.removeEventListener("task-component:display", this.display)
+  }
+
+  autoResize(event) {
+    if (event.target.tagName !== "TEXTAREA") return;
+
+    const textarea = event.target
+
+    textarea.style.height = "auto"
+    textarea.style.height = `${textarea.scrollHeight}px`
+  }
+
+  selectOnFocus(event) {
+    event.target.select()
+  }
+
+  display(event) {
+    this.editTarget.classList.add("hidden");
+    this.displayTarget.classList.remove("hidden");
+  }
+
+  edit(event) {
+    this.displayTarget.classList.add("hidden");
+    this.editTarget.classList.remove("hidden");
+
+    if (this.element.contains(event.explicitOriginalTarget)) {
+      const input = this.editTarget.querySelector(":is(input,textarea):not([type=hidden])");
+
+      input.focus();
+    }
+  }
+}

--- a/app/components/controllers/task_component_controller.js
+++ b/app/components/controllers/task_component_controller.js
@@ -1,0 +1,37 @@
+import {Controller} from "@hotwired/stimulus";
+
+export default class extends Controller {
+  static targets = ["attribute"]
+  connect() {
+    this.handleInsideClick = this.handleInsideClick.bind(this);
+    this.handleOutsideClick = this.handleOutsideClick.bind(this);
+
+    document.addEventListener("click", this.handleInsideClick);
+    document.addEventListener("click", this.handleOutsideClick);
+  }
+
+  disconnect() {
+  }
+
+  handleInsideClick(event) {
+    if (this.element.contains(event.target)) {
+      this.editAttributes();
+    }
+  }
+
+  handleOutsideClick(event) {
+    if (!this.element.contains(event.target)) {
+      this.displayAttributes();
+    }
+  }
+
+  displayAttributes() {
+    this.element.classList.remove("bg-accent");
+    this.dispatch("display");
+  }
+
+  editAttributes() {
+    this.element.classList.add("bg-accent");
+    this.dispatch("edit");
+  }
+}

--- a/app/components/task_attribute_component.html.erb
+++ b/app/components/task_attribute_component.html.erb
@@ -1,0 +1,6 @@
+<div data-controller="task-attribute-component" data-task-component-target="attribute">
+  <% if render_display? %>
+    <div class="cursor-default" data-task-attribute-component-target="display"><%= display %></div>
+  <% end %>
+  <div class="hidden" data-task-attribute-component-target="edit"><%= edit %></div>
+</div>

--- a/app/components/task_attribute_component.rb
+++ b/app/components/task_attribute_component.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class TaskAttributeComponent < ViewComponent::Base
+  renders_one :display
+  renders_one :edit
+
+  attr_reader :task, :attribute
+
+  def initialize(task:, attribute:)
+    @task = task
+    @attribute = attribute
+  end
+
+  def render_display?
+    task.public_send(attribute).present?
+  end
+end

--- a/app/components/task_component.html.erb
+++ b/app/components/task_component.html.erb
@@ -1,0 +1,82 @@
+<div id="<%= dom_id(task) %>" class="flex p-1 hover:bg-accent" data-controller="task-component">
+  <%= form_with(model: task, class: "flex flex-grow") do |form| %>
+    <label class="group">
+      <span class="w-4 h-4 mx-4 my-1 cursor-pointer rounded-full border-1 border-neutral group-has-[input:checked]:border-secondary bg-transparent flex items-center justify-center transition">
+        <%= check_box_tag :completed, id: dom_id(task, :completed), class: "sr-only peer", autocomplete: "off" %>
+        <svg class="w-4 h-4 hidden peer-checked:block text-secondary" fill="currentColor" stroke="currentColor" viewBox="0 0 16 16">
+          <path d="M12.207 4.793a1 1 0 010 1.414l-5 5a1 1 0 01-1.414 0l-2-2a1 1 0 011.414-1.414L6.5 9.086l4.293-4.293a1 1 0 011.414 0z"/>
+        </svg>
+      </span>
+    </label>
+
+    <div class="flex flex-grow flex-col">
+      <!-- Task (tasks/show) -->
+      <div class="flex flex-col">
+        <%= render TaskAttributeComponent.new(task: task, attribute: :title) do |component| %>
+          <% component.with_display do %>
+            <%= task.title %>
+          <% end %>
+          <%= component.with_edit do %>
+            <%= form.text_field :title, id: dom_id(task, :title), class: "w-full bg-transparent border-none ring-0 p-0", placeholder: "Title", autocomplete: "off" %>
+          <% end %>
+        <% end %>
+        <%= render TaskAttributeComponent.new(task: task, attribute: :description) do |component| %>
+          <% component.with_display do %>
+            <div class="text-xs opacity-75"><%= task.description %></div>
+          <% end %>
+          <% component.with_edit do %>
+            <%= form.text_area :description, id: dom_id(task, :description), class: "w-full text-xs opacity-75 bg-transparent border-none ring-0 p-0 resize-none", rows: 1, placeholder: "Description", autocomplete: "off" %>
+          <% end %>
+        <% end %>
+      </div>
+
+      <%= render TaskAttributeComponent.new(task: task, attribute: :due_at) do |component| %>
+        <% component.with_display do %>
+          <%= render DatetimePickerComponent.new do |component| %>
+            <% component.with_datetime_badge do %>
+              <%= formatted_due_at || helpers.inline_svg("calendar-circle-plus-svgrepo-com.svg", class: "h-4 w-4", aria: { label: "Open date and time picker" }) %>
+            <% end %>
+            <% component.with_date_field do %>
+              <%= form.date_field :due_date, autocomplete: "off", class: "hidden" %>
+            <% end %>
+            <% component.with_time_field do %>
+              <%= form.text_field :due_time, autocomplete: "off", class: "w-full p-2 text-sm placeholder-neutral bg-transparent border-0 ring-0", placeholder: "Set time" %>
+            <% end %>
+          <% end %>
+        <% end %>
+        <% component.with_edit do %>
+          <%= render DatetimePickerComponent.new do |component| %>
+            <% component.with_datetime_badge do %>
+              <%= formatted_due_at || helpers.inline_svg("calendar-circle-plus-svgrepo-com.svg", class: "h-4 w-4", aria: { label: "Open date and time picker" }) %>
+            <% end %>
+            <% component.with_date_field do %>
+              <%= form.date_field :due_date, autocomplete: "off", class: "hidden" %>
+            <% end %>
+            <% component.with_time_field do %>
+              <%= form.text_field :due_time, autocomplete: "off", class: "w-full p-2 text-sm placeholder-neutral bg-transparent border-0 ring-0", placeholder: "Set time" %>
+            <% end %>
+          <% end %>
+        <% end %>
+      <% end %>
+    </div>
+  <% end %>
+
+  <% if task.persisted? %>
+    <div class="relative flex items-center" data-controller="dropdown">
+      <span class="px-2 py-1 cursor-pointer rounded-lg hover:bg-rose-400" data-action="click->dropdown#toggle click@window->dropdown#hide">
+        &#x22EE;
+      </span>
+
+      <div class="hidden flex flex-col absolute right-0 top-10 z-10 rounded-lg py-2 bg-slate-800 border border-slate-800"
+           data-dropdown-target="menu"
+           data-transition-enter="transition ease-out duration-200"
+           data-transition-enter-from="opacity-0 translate-y-1"
+           data-transition-enter-to="opacity-100 translate-y-0"
+           data-transition-leave="transition ease-in duration-150"
+           data-transition-leave-from="opacity-100 translate-y-0"
+           data-transition-leave-to="opacity-0 translate-y-1">
+        <span class="cursor-pointer px-8 py-2 hover:bg-rose-400">Delete</span>
+      </div>
+    </div>
+  <% end %>
+</div>

--- a/app/components/task_component.rb
+++ b/app/components/task_component.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+class TaskComponent < ViewComponent::Base
+  attr_reader :task
+
+  delegate :due_at, :has_due_time, to: :task
+
+  def initialize(task:)
+    @task = task
+  end
+
+  private
+
+  def formatted_due_at
+    return unless task.due_at.present?
+
+    formatted_date = due_at.strftime("%a, %b %-d")
+    formatted_date += ", #{due_at.year}" if due_at.year != Time.current.year
+    formatted_date += " at #{due_at.strftime("%l:%M %p").strip}" if has_due_time.present?
+    formatted_date
+  end
+end

--- a/test/components/previews/task_attribute_component_preview.rb
+++ b/test/components/previews/task_attribute_component_preview.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+class TaskAttributeComponentPreview < ViewComponent::Preview
+  def default
+  end
+end

--- a/test/components/previews/task_attribute_component_preview/default.html.erb
+++ b/test/components/previews/task_attribute_component_preview/default.html.erb
@@ -1,0 +1,7 @@
+<% task = Task.new(description: "My Description") %>
+
+<%= render(TaskAttributeComponent.new(task: task, attribute: :description)) do |component| %>
+  <% component.with_display do %>
+    <%= task.description %>
+  <% end %>
+<% end %>

--- a/test/components/previews/task_component_preview.rb
+++ b/test/components/previews/task_component_preview.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+class TaskComponentPreview < ViewComponent::Preview
+  def default
+  end
+end

--- a/test/components/previews/task_component_preview/default.html.erb
+++ b/test/components/previews/task_component_preview/default.html.erb
@@ -1,0 +1,9 @@
+<% task = Task.new(
+  title:        "The title of the task",
+  description:  "Some additional details about this task",
+  due_at:       Time.zone.now + 1.hour,
+  has_due_time: true,
+  ) %>
+<div class="bg-primary">
+  <%= render(TaskComponent.new(task: task)) %>
+</div>

--- a/test/components/task_attribute_component_test.rb
+++ b/test/components/task_attribute_component_test.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class TaskAttributeComponentTest < ViewComponent::TestCase
+  def test_component_renders_something_useful
+    # assert_equal(
+    #   %(<span>Hello, components!</span>),
+    #   render_inline(TaskAttributeComponent.new(message: "Hello, components!")).css("span").to_html
+    # )
+  end
+end

--- a/test/components/task_component_test.rb
+++ b/test/components/task_component_test.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class TaskComponentTest < ViewComponent::TestCase
+  def test_component_renders_something_useful
+    # assert_equal(
+    #   %(<span>Hello, components!</span>),
+    #   render_inline(TaskComponent.new(message: "Hello, components!")).css("span").to_html
+    # )
+  end
+end


### PR DESCRIPTION
dependent on: #4 

- Introduce `TaskComponent` to encapsulate task-related behavior and styling.
- Add `TaskAttributeComponent` to handle editable task attributes like title, description, and due date.
- Include corresponding Stimulus controllers to manage interactions between display and edit modes.
- Provide component previews for `TaskComponent` and `TaskAttributeComponent` for easier testing and visualization.
- Add placeholder tests for components to ensure future functionality.
