### PR TITLE
add tests for task model and controllers

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -61,6 +61,7 @@ group :test do
   # Use system testing [https://guides.rubyonrails.org/testing.html#system-testing]
   gem "capybara"
   gem "selenium-webdriver"
+  gem "mocha", "~> 2.7"
 end
 
 gem "devise", "~> 4.9"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -163,6 +163,8 @@ GEM
     method_source (1.1.0)
     mini_mime (1.1.5)
     minitest (5.25.5)
+    mocha (2.7.1)
+      ruby2_keywords (>= 0.0.5)
     msgpack (1.8.0)
     net-imap (0.5.8)
       date
@@ -295,6 +297,7 @@ GEM
       rubocop-performance (>= 1.24)
       rubocop-rails (>= 2.30)
     ruby-progressbar (1.13.0)
+    ruby2_keywords (0.0.5)
     rubyzip (2.4.1)
     securerandom (0.4.1)
     selenium-webdriver (4.33.0)
@@ -395,6 +398,7 @@ DEPENDENCIES
   importmap-rails
   jbuilder
   kamal
+  mocha (~> 2.7)
   pg (~> 1.1)
   propshaft
   puma (>= 5.0)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,2 @@
 class ApplicationController < ActionController::Base
-  def dashboard
-    render html: "Hello, world!"
-  end
 end

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -1,68 +1,57 @@
 class TasksController < ApplicationController
-  before_action :set_task, only: [:show, :edit, :update, :destroy]
+  before_action :set_task, only: [:update, :destroy]
 
-  # GET /tasks
   def index
-    @tasks = Task.incomplete.position.order(created_at: :desc)
+    @tasks           = Task.incomplete.position.order(created_at: :desc)
     @completed_tasks = Task.complete.position.order(created_at: :desc)
   end
 
-  # GET /tasks/1 or /tasks/1.json
-  def show
-    respond_to do |format|
-      format.turbo_stream
-    end
-  end
+  # def show
+  # end
+  #
+  # def new
+  #   @task = Task.new
+  # end
+  #
+  # def edit
+  # end
 
-  # GET /tasks/new
-  def new
-    @task = Task.new
-
-    respond_to do |format|
-    end
-  end
-
-  # GET /tasks/1/edit
-  def edit
-  end
-
-  # POST /tasks or /tasks.json
   def create
     @task = Task.new(task_params.merge(user: current_user))
 
     respond_to do |format|
-      if @task.save
-        @dom_id = params[:dom_id]
+      @dom_id = params[:dom_id]
 
+      if @task.save
         format.turbo_stream
-        format.json { head :no_content }
       else
-        format.json { render json: { errors: @task.errors }, status: :unprocessable_entity }
+        format.turbo_stream do
+          render status: :bad_request, json: { errors: @task.errors.full_messages }
+        end
       end
     end
   end
 
-  # PATCH/PUT /tasks/1 or /tasks/1.json
   def update
     respond_to do |format|
       if @task.update(task_params)
-        @dom_id = params[:dom_id]
+        @dom_id               = params[:dom_id]
         @completed_tasks_size = Task.complete.size
 
         format.turbo_stream
-        format.json { head :no_content }
       else
-        format.json { render json: { errors: @task.errors }, status: :unprocessable_entity }
+        format.turbo_stream do
+          render status: :bad_request, json: { errors: @task.errors.full_messages }
+        end
       end
     end
   end
 
-  # DELETE /tasks/1 or /tasks/1.json
   def destroy
     @task.destroy!
+
     respond_to do |format|
       format.turbo_stream
-      format.json { head :no_content }
     end
   end
 
@@ -76,15 +65,13 @@ class TasksController < ApplicationController
 
   private
 
-  # Use callbacks to share common setup or constraints between actions.
   def set_task
     @task = Task.find(params.expect(:id))
   rescue ActiveRecord::RecordNotFound
     redirect_to tasks_path
   end
 
-  # Only allow a list of trusted parameters through.
   def task_params
-    params.expect(task: [ :title, :description, :due_date, :due_time, :completed ])
+    params.expect(task: [:title, :description, :due_date, :due_time, :completed])
   end
 end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -7,7 +7,6 @@ class Task < ApplicationRecord
   scope :incomplete, -> { where(completed_at: nil) }
   scope :complete, -> { where.not(completed_at: nil) }
   scope :position, -> { order(position: :asc) }
-  scope :default_sort, -> { position.order(created_at: :desc) }
 
   def completed
     completed_at.present?
@@ -38,11 +37,13 @@ class Task < ApplicationRecord
   end
 
   def due_time
+    return unless has_due_time || @due_time.present?
+
     @due_time || due_at&.strftime("%l:%M %p")
   end
 
   def due_time=(value)
-    @due_time = value.is_a?(String) ? Time.zone.parse(value)&.strftime("%H:%M") : value&.strftime("%H:%M")
+    @due_time = value.is_a?(String) ? Time.zone.parse(value)&.strftime("%l:%M %p") : value&.strftime("%l:%M %p")
   end
 
   def due_at=(value)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,7 +17,7 @@ Rails.application.routes.draw do
 
   root to: redirect("/users/sign_in")
 
-  resources :tasks do
+  resources :tasks, except: [:new, :show, :edit] do
     collection do
       post "reorder"
     end

--- a/test/controllers/tasks_controller_test.rb
+++ b/test/controllers/tasks_controller_test.rb
@@ -148,7 +148,7 @@ class TasksControllerTest < ActionDispatch::IntegrationTest
 
     assert_no_difference("Task.count") do
       assert_raises ActiveRecord::RecordNotDestroyed do
-        delete task_path(task), as: :turbo_stream
+        delete task_url(task), as: :turbo_stream
       end
     end
   end

--- a/test/controllers/tasks_controller_test.rb
+++ b/test/controllers/tasks_controller_test.rb
@@ -1,0 +1,155 @@
+require "test_helper"
+
+class TasksControllerTest < ActionDispatch::IntegrationTest
+  include Devise::Test::IntegrationHelpers
+
+  attr_reader :task, :user
+
+  setup do
+    @task = tasks(:task_minimal)
+    @user = users(:jonathan)
+
+    sign_in user
+  end
+
+  test "should get index" do
+    get tasks_url
+
+    assert_response :success
+  end
+
+  test "new is not a route" do
+    get tasks_url + "/new"
+
+    assert_response :not_found
+  end
+
+  test "show is not a route" do
+    get task_url(@task)
+
+    assert_response :not_found
+  end
+
+  test "edit is not a route" do
+    get task_url(@task) + "/edit"
+
+    assert_response :not_found
+  end
+
+  test "should create task" do
+    new_task = Task.new(title: "New Task", description: "Task Description")
+
+    assert_difference("Task.count") do
+      post tasks_url,
+           as:     :turbo_stream,
+           params: {
+             task: {
+               title:       new_task.title,
+               description: new_task.description,
+               due_date:    Date.tomorrow,
+               due_time:    "2:00 PM"
+             }
+           }
+    end
+
+    task = Task.last
+
+    assert_response :success
+    assert_equal new_task.title, task.title
+    assert_equal new_task.description, task.description
+    assert_includes response.body, task.title
+    assert_includes response.body, task.description
+  end
+
+  test "create task fails" do
+    Task.any_instance.expects(:save).returns(false)
+
+    assert_no_difference("Task.count") do
+      post tasks_url,
+           as:     :turbo_stream,
+           params: {
+             task: {
+               title:       "New Task",
+               description: "Task Description",
+               due_date:    Date.tomorrow,
+               due_time:    "2:00 PM"
+             }
+           }
+    end
+
+    assert_response :bad_request
+    assert_includes response.body, "errors"
+  end
+
+  test "should update task" do
+    patch task_url(@task),
+          as:     :turbo_stream,
+          params: {
+            task: {
+              title:       "Updated Title",
+              description: "Updated Description"
+            }
+          }
+
+    task.reload
+
+    assert_response :success
+    assert_equal "Updated Title", task.title
+    assert_equal "Updated Description", task.description
+    assert_includes response.body, task.title
+    assert_includes response.body, task.description
+    refute_includes response.body, "completed-count"
+  end
+
+  test "update task when completed_at changed" do
+    patch task_url(@task),
+          as:     :turbo_stream,
+          params: {
+            task: {
+              completed: "1"
+            }
+          }
+
+    task.reload
+
+    assert_response :success
+    assert_includes response.body, "completed-count"
+  end
+
+  test "update task fails" do
+    Task.any_instance.expects(:update).returns(false)
+
+    patch task_url(@task),
+          as:     :turbo_stream,
+          params: {
+            task: {
+              title:       "Updated Title",
+              description: "Updated Description"
+            }
+          }
+
+    task.reload
+
+    assert_response :bad_request
+    assert_includes response.body, "errors"
+  end
+
+  test "should destroy task" do
+    assert_difference("Task.count", -1) do
+      delete task_url(task), as: :turbo_stream
+    end
+
+    assert_response :success
+    assert_includes response.body, %(turbo-stream action="remove")
+  end
+
+  test "destroy task fails" do
+    Task.any_instance.expects(:destroy!).raises(ActiveRecord::RecordNotDestroyed)
+
+    assert_no_difference("Task.count") do
+      assert_raises ActiveRecord::RecordNotDestroyed do
+        delete task_path(task), as: :turbo_stream
+      end
+    end
+  end
+end

--- a/test/fixtures/tasks.yml
+++ b/test/fixtures/tasks.yml
@@ -11,24 +11,29 @@ task_minimal:
   user: jonathan
   title: Minimal Task
   description: Only title and description
+  position: 0
 
 task_no_description:
   user: jonathan
   title: No Description Task
   due_at: <%= 2.days.from_now %>
+  position: 1
 
 task_only_title:
   user: jonathan
   title: Just a Title
+  position: 2
 
 task_future:
   user: jonathan
   title: Future Task
   description: This task is due in the future
   due_at: <%= 1.week.from_now %>
+  position: 3
 
 task_with_time:
   user: jonathan
   title: Task with due time
   description: Task with due date and due time
   due_at: <%=  Time.zone.at(2.days.from_now) %>
+  position: 4

--- a/test/models/task_test.rb
+++ b/test/models/task_test.rb
@@ -1,0 +1,121 @@
+require "test_helper"
+
+class TaskTest < ActiveSupport::TestCase
+  attr_reader :user, :new_task
+
+  def setup
+    freeze_time
+
+    @user = users(:jonathan)
+    @new_task = Task.new(
+      title:       "Test Task",
+      description: "Test Description",
+      user:        @user
+    )
+  end
+
+  def teardown
+    unfreeze_time
+  end
+
+  def test_combine_due_date_and_time
+    new_task.due_date = "2021-01-01"
+    new_task.due_time = "12:00"
+
+    assert new_task.valid?
+    assert_equal Time.zone.parse("2021-01-01 12:00:00"), new_task.due_at
+  end
+
+  def test_combine_due_date_and_time_when_due_date_is_blank
+    new_task.due_time = "12:00"
+
+    assert new_task.valid?
+    refute new_task.has_due_time
+    refute new_task.due_at.present?
+  end
+
+  def test_incomplete_scope
+    incomplete_tasks = Task.incomplete
+
+    assert_equal 5, Task.incomplete.count
+    incomplete_tasks.each do |task|
+      assert_equal false, task.completed?
+    end
+  end
+
+  def test_complete_scope
+    complete_tasks = Task.complete
+
+    assert_equal 1, Task.complete.count
+    complete_tasks.each do |task|
+      assert_equal true, task.completed?
+    end
+  end
+
+  def test_position_scope
+    tasks = Task.incomplete.position
+
+    tasks.each_cons(2) do |previous_task, current_task|
+      assert current_task.position > previous_task.position, "Task positions should be in ascending order"
+    end
+  end
+
+  def test_set_completed
+    refute new_task.completed
+
+    new_task.completed = true
+
+    assert new_task.completed
+    assert_equal Time.current, new_task.completed_at
+  end
+
+  def test_due_date
+    refute new_task.due_at.present?
+    refute new_task.due_date.present?
+
+    new_task.update!(due_date: 2.days.from_now)
+
+    assert_equal 2.days.from_now.beginning_of_day, new_task.due_at
+    assert_instance_of Date, new_task.due_date
+  end
+
+  def test_due_time
+    task = tasks(:task_future)
+
+    assert task.due_at.present?
+    refute task.has_due_time
+    refute new_task.due_time.present?
+
+    task.has_due_time = true
+
+    assert task.due_at.strftime("%l:%M %p"), task.due_time
+  end
+
+  def test_due_time_setter_with_datetime
+    task = tasks(:task_future)
+
+    refute task.due_time.present?
+
+    task.due_time = 2.days.from_now
+
+    assert 2.days.from_now.strftime("%l:%M %p"), task.due_time
+  end
+
+  def test_due_time_setter_with_string
+    task = tasks(:task_future)
+
+    refute task.due_time.present?
+
+    task.due_time = 2.days.from_now.strftime("H:M")
+
+    assert 2.days.from_now.strftime("%l:%M %p"), task.due_time
+  end
+
+  def test_due_time_with_invalid_time
+    task = tasks(:task_future)
+
+    task.due_time = "not valid"
+
+    assert_nil task.due_time
+  end
+end

--- a/test/models/task_test.rb
+++ b/test/models/task_test.rb
@@ -88,7 +88,7 @@ class TaskTest < ActiveSupport::TestCase
 
     task.has_due_time = true
 
-    assert task.due_at.strftime("%l:%M %p"), task.due_time
+    assert_equal task.due_at.strftime("%l:%M %p"), task.due_time
   end
 
   def test_due_time_setter_with_datetime
@@ -98,7 +98,7 @@ class TaskTest < ActiveSupport::TestCase
 
     task.due_time = 2.days.from_now
 
-    assert 2.days.from_now.strftime("%l:%M %p"), task.due_time
+    assert_equal 2.days.from_now.strftime("%l:%M %p"), task.due_time
   end
 
   def test_due_time_setter_with_string
@@ -106,9 +106,9 @@ class TaskTest < ActiveSupport::TestCase
 
     refute task.due_time.present?
 
-    task.due_time = 2.days.from_now.strftime("H:M")
+    task.due_time = 2.days.from_now.strftime("%H:%M")
 
-    assert 2.days.from_now.strftime("%l:%M %p"), task.due_time
+    assert_equal 2.days.from_now.strftime("%l:%M %p"), task.due_time
   end
 
   def test_due_time_with_invalid_time

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,6 +1,7 @@
 ENV["RAILS_ENV"] ||= "test"
 require_relative "../config/environment"
 require "rails/test_help"
+require "mocha/minitest"
 
 module ActiveSupport
   class TestCase


### PR DESCRIPTION
closes #15 

This pull request introduces several changes to streamline the `Tasks` feature by simplifying the controller, improving model behavior, and enhancing test coverage. The most notable updates include removing unused actions and routes, refining the `Task` model's handling of due dates and times, and adding comprehensive tests to ensure functionality and edge cases are covered.

### Controller and Routing Changes:
* Removed unused actions (`new`, `show`, `edit`) from `TasksController` and their associated routes to simplify the controller and align with the application's requirements. (`app/controllers/tasks_controller.rb`, `config/routes.rb`) [[1]](diffhunk://#diff-de1aaaf7a00c963e6a5e77045d8cbdafa5ebc81e1250a7ea1862a51d824e9945L2-L65) [[2]](diffhunk://#diff-959bc9abc46a55332bb64d5155a79323afa75a50ec1a2137ddd22d926f62c6c5L20-R20)
* Updated the `create` and `update` actions to return detailed error messages in Turbo Stream responses when validation fails. (`app/controllers/tasks_controller.rb`)

### Model Improvements:
* Removed the unused `default_sort` scope from the `Task` model and refined the `due_time` setter to handle formatting more consistently. (`app/models/task.rb`) [[1]](diffhunk://#diff-4095b65754098dce7229824782d43e80a7cb3f0fe45aa245102593760b51a24bL10) [[2]](diffhunk://#diff-4095b65754098dce7229824782d43e80a7cb3f0fe45aa245102593760b51a24bR40-R46)

### Test Enhancements:
* Added new integration tests for `TasksController` to validate the updated behavior of actions and ensure removed routes (`new`, `show`, `edit`) are inaccessible. (`test/controllers/tasks_controller_test.rb`)
* Introduced unit tests for the `Task` model to verify scopes, due date/time logic, and edge cases. (`test/models/task_test.rb`)

### Miscellaneous:
* Added the `mocha` gem for mocking in tests and updated test helper files to include `mocha/minitest`. (`Gemfile`, `test/test_helper.rb`) [[1]](diffhunk://#diff-d09ea66f8227784ff4393d88a19836f321c915ae10031d16c93d67e6283ab55fR64) [[2]](diffhunk://#diff-ba37813ca277c227a74a372479b7b05b7f3ff085d890ab708f80d62573efdb7aR4)
* Updated task fixtures to include `position` attributes for testing the `position` scope. (`test/fixtures/tasks.yml`)